### PR TITLE
docs: Add section on blocking admin password authentication.

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -3,6 +3,39 @@
 **Django Microsoft SSO** integrates with Django Admin, adding an Inline Model Admin to the User model. This way, you can
 access the Microsoft SSO data for each user.
 
+## Blocking password authentication
+
+Setting `SSO_SHOW_FORM_ON_ADMIN_PAGE=False` doesn't block the default admin site's password login api. For that you
+would need to override the default admin site's login method. Here is an example:
+
+```python
+from typing import Any
+
+from django.conf import settings
+from django.contrib import admin
+from django.contrib.admin.apps import AdminConfig
+from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
+
+
+class MyAdminSite(admin.AdminSite):
+    ...
+    
+    def login(
+        self, request: HttpRequest, extra_context: dict[str, Any] | None = None
+    ) -> HttpResponse:
+       if request.method != "GET" and not settings.SSO_SHOW_FORM_ON_ADMIN_PAGE:
+            return HttpResponseNotAllowed(["GET"])
+        return super().login(request, extra_context)
+
+
+class MyAdminConfig(AdminConfig):
+    default_site = "path.to.MyAdminSite"
+```
+
+See [Django docs](https://docs.djangoproject.com/en/stable/ref/contrib/admin/#overriding-the-default-admin-site)
+for more information on how to override the default admin site.
+
+
 ## Using Custom User model
 
 If you are using a custom user model, you may need to add the `MicrosoftSSOInlineAdmin` inline model admin to your custom


### PR DESCRIPTION
### Contains
- [ ] Breaking Changes
- [x] New/Update documentation
- [ ] CI/CD modifications

### Changes
*  Added documentation on blocking password authentication for django admin, as this is not handled by the package and users may get the impression that it is.

Thanks for this great package. When we started to use it we wanted to verify that users won't be able to submit the form anyway and that SSO was the only way to login. The package could possibly also contain a drop-in `django.contrib.admin` replacement but that would make customization more complicated so I preferred to just document a simple way to block password authentication.